### PR TITLE
Fix explicit MCE::Queue::dequeue(1) in manager

### DIFF
--- a/lib/MCE/Queue.pm
+++ b/lib/MCE/Queue.pm
@@ -1151,7 +1151,7 @@ sub _mce_m_dequeue {
 
    $_Q->{_nb_flag} = 0;
 
-   return @_items if (defined $_cnt);
+   return @_items if (defined $_cnt && $_cnt ne '1');
    return $_buf;
 }
 

--- a/t/04_norm_que_manager.t
+++ b/t/04_norm_que_manager.t
@@ -36,15 +36,16 @@ my (@a, $q, @r);
 
 $q->enqueue('1', '2');
 $q->enqueue('3');
-$q->enqueue('4');
+$q->enqueue('4', '5');
 
-is( join('', @a), '1234', 'fifo, check enqueue' );
+is( join('', @a), '12345', 'fifo, check enqueue' );
 
 @r = $q->dequeue(2);
 push @r, $q->dequeue;
+push @r, $q->dequeue(1); # Dequeue 1 explicitly
 
-is( join('', @r), '123', 'fifo, check dequeue' );
-is( join('', @a),   '4', 'fifo, check array'   );
+is( join('', @r), '1234', 'fifo, check dequeue' );
+is( join('', @a),   '5', 'fifo, check array'   );
 
 $q->clear;
 


### PR DESCRIPTION
Example of bug:

``` perl
use DDP;
use MCE;
use MCE::Queue;

my $queue = MCE::Queue->new();
$queue->enqueue(1..5);
my @things = (
    $queue->dequeue,    # works
    $queue->dequeue(1)  # dequeues from queue, but does not return the value
);
p @things;
p $queue;
```

This pull request adds a test for explicit `$queue->dequeue(1)` from the manager and fixes the issue.

This issue was not witnessed from the child processes.
