### PR TITLE
fix two typos

### DIFF
--- a/lib/MCE/Examples.pod
+++ b/lib/MCE/Examples.pod
@@ -796,7 +796,7 @@ for C<IO::TieCombine> must be C<stdout> or C<stderr> for MCE->print to work.
       print "ordered: no\n";
    }
 
-   -- Ouput
+   -- Output
 
    ordered: yes
 

--- a/lib/MCE/Util.pm
+++ b/lib/MCE/Util.pm
@@ -476,7 +476,7 @@ In summary:
  1. Auto has an upper-limit of 8 in MCE 1.521 (# of lcores, 8 maximum)
  2. Math can be applied with auto (*/+-) to change the upper limit
  3. The computed value for auto will not exceed the total # of lcores
- 4. One can specify max_workers explicity to a hard value
+ 4. One can specify max_workers explicitly to a hard value
  5. MCE::Util::get_ncpu returns the actual # of lcores
 
 =head1 ACKNOWLEDGMENTS


### PR DESCRIPTION
found by Debian's lintian checker
