### PR TITLE
fix typos caught by lintian.

### DIFF
--- a/lib/MCE/Channel/Mutex.pm
+++ b/lib/MCE/Channel/Mutex.pm
@@ -323,7 +323,7 @@ The API is described in L<MCE::Channel>.
  my $chnl_a = MCE::Channel->new( impl => 'Mutex' );
 
  # Specify the 'mp' option for safe use by two or more producers
- # sending or recieving on the left side of the channel (i.e.
+ # sending or receiving on the left side of the channel (i.e.
  # ->enqueue/->send or ->recv2/->recv2_nb).
 
  my $chnl_b = MCE::Channel->new( impl => 'Mutex', mp => 1 );

--- a/lib/MCE/Channel/MutexFast.pm
+++ b/lib/MCE/Channel/MutexFast.pm
@@ -335,7 +335,7 @@ Current module available since MCE 1.877.
  my $chnl_a = MCE::Channel->new( impl => 'MutexFast' );
 
  # Specify the 'mp' option for safe use by two or more producers
- # sending or recieving on the left side of the channel (i.e.
+ # sending or receiving on the left side of the channel (i.e.
  # ->enqueue/->send or ->recv2/->recv2_nb).
 
  my $chnl_b = MCE::Channel->new( impl => 'MutexFast', mp => 1 );

--- a/lib/MCE/Channel/Threads.pm
+++ b/lib/MCE/Channel/Threads.pm
@@ -339,7 +339,7 @@ The API is described in L<MCE::Channel>.
  my $chnl_a = MCE::Channel->new( impl => 'Threads' );
 
  # Specify the 'mp' option for safe use by two or more producers
- # sending or recieving on the left side of the channel (i.e.
+ # sending or receiving on the left side of the channel (i.e.
  # ->enqueue/->send or ->recv2/->recv2_nb).
 
  my $chnl_b = MCE::Channel->new( impl => 'Threads', mp => 1 );

--- a/lib/MCE/Channel/ThreadsFast.pm
+++ b/lib/MCE/Channel/ThreadsFast.pm
@@ -353,7 +353,7 @@ Current module available since MCE 1.877.
  my $chnl_a = MCE::Channel->new( impl => 'ThreadsFast' );
 
  # Specify the 'mp' option for safe use by two or more producers
- # sending or recieving on the left side of the channel (i.e.
+ # sending or receiving on the left side of the channel (i.e.
  # ->enqueue/->send or ->recv2/->recv2_nb).
 
  my $chnl_b = MCE::Channel->new( impl => 'ThreadsFast', mp => 1 );

--- a/lib/MCE/Core/Input/Iterator.pm
+++ b/lib/MCE/Core/Input/Iterator.pm
@@ -2,7 +2,7 @@
 ## ----------------------------------------------------------------------------
 ## Iterator reader.
 ##
-## This package, used interally by the worker process, provides support for
+## This package, used internally by the worker process, provides support for
 ## user specified iterators assigned to input_data.
 ##
 ## There is no public API.
@@ -133,7 +133,7 @@ This document describes MCE::Core::Input::Iterator version 1.887
 
 =head1 DESCRIPTION
 
-This package, used interally by the worker process, provides support for
+This package, used internally by the worker process, provides support for
 user specified iterators assigned to C<input_data>.
 
 There is no public API.


### PR DESCRIPTION
Hi,

These typos surfaced mainly because they propagated through perldoc to the manual pages of the module, otherwise our linter for Debian packaging might not have caught them.

Have a nice day,  :)
Étienne.